### PR TITLE
SIMD DSP calculations computed and logged from both C and Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ opt-level = 3
 
 [dependencies]
 log = "0.4.17"
-logz = "0.1.1"
+logz = "0.1.2"
 
 
 [build-dependencies]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -6,30 +6,30 @@ args = ["--config", "cbindgen.toml", "--crate", "logz-example-rs", "--output", "
 
 [tasks.build-nrf52]
 command = "cargo"
-toolchain = "stable"
-args = ["build", "--lib", "--target", "thumbv7em-none-eabihf", "--release"] 
+toolchain = "nightly"
+args = ["build", "--lib", "--target", "thumbv7em-none-eabihf", "--release", "--verbose"] 
 dependencies = ["cbindgen"]
 
 [tasks.build-nrf53]
 command = "cargo"
-toolchain = "stable"
-args = ["build", "--lib", "--target", "thumbv8m.main-none-eabihf", "--release"]
+toolchain = "nightly"
+args = ["build", "--lib", "--target", "thumbv8m.main-none-eabihf", "--release", "--verbose"]
 dependencies = ["cbindgen"]
 
 [tasks.build]
 command = "cargo"
-toolchain = "stable"
+toolchain = "nightly"
 args = ["build"]
 dependencies = ["build-nrf52", "build-nrf53"]
 
 [tasks.test-release]
 command = "cargo"
-toolchain = "stable"
+toolchain = "nightly"
 args = ["test", "--lib", "--release"]
 dependencies = ["build"]
 
 [tasks.test]
 command = "cargo"
-toolchain = "stable"
+toolchain = "nightly"
 args = ["test", "--lib"]
 dependencies = ["test-release"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# LOGZ Example Library
+
+This library includes logz as a crate to provide an Logger implementation and uses the `log` crate macros for logging. `lib/logz` is included as a submodule as well for ease of compilation in the consumnig Zephyr RTOS application
+
+A full example application is implemented: https://github.com/trueb2/logz-example-blinky.

--- a/include/generated/liblogz_example_rs.h
+++ b/include/generated/liblogz_example_rs.h
@@ -12,4 +12,6 @@
 
 void example_foo(void);
 
+void example_foo(void);
+
 #endif /* LOGZ_EXAMPLE_RS_INCLUDE_GENERATED_LIB_LOGZ_EXAMPLE_RS_H */

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ static mut ACC: u32 = 0;
 #[target_feature(enable = "dsp")]
 #[no_mangle]
 pub unsafe extern "C" fn example_foo() {
-    // log::trace!("Foo");
-    // log::debug!("Bar");
-    // log::info!("Fizz");
-    // log::warn!("Buzz");
-    // log::error!("Fizzle");
+    log::trace!("Foo");
+    log::debug!("Bar");
+    log::info!("Fizz");
+    log::warn!("Buzz");
+    log::error!("Fizzle");
     let a: u32 = ACC;
     let b: u32 = 0x01020304;
     let c: u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,51 @@
 #![cfg_attr(not(test), no_std, no_main)]
 #![cfg_attr(test, allow(unused))]
+#![cfg_attr(not(test), feature(arm_target_feature))]
+#![feature(cfg_target_abi)]
 
 #[cfg(test)]
 #[macro_use]
 extern crate std;
+#[cfg(target_abi = "eabihf")]
+use core::arch::asm;
 #[cfg(test)]
 use std::prelude::*;
 
+#[allow(unused_imports)]
 use log;
 #[allow(unused_imports)] // Bad warning, this implements panic_handler
 #[cfg(not(test))]
 use logz::fatal::panic;
-pub use logz::LOGZ_LOGGER;
 
 // #[cfg(not(test))] #[panic_handler]
 // pub fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
 //     todo!()
 // }
 
+#[cfg(target_abi = "eabihf")]
+static mut ACC: u32 = 0;
+
+#[cfg(target_abi = "eabihf")]
+#[target_feature(enable = "dsp")]
 #[no_mangle]
-pub extern "C" fn example_foo() {
-    log::trace!("Foo");
-    log::debug!("Bar");
-    log::info!("Fizz");
-    log::warn!("Buzz");
-    log::error!("Fizzle");
+pub unsafe extern "C" fn example_foo() {
+    // log::trace!("Foo");
+    // log::debug!("Bar");
+    // log::info!("Fizz");
+    // log::warn!("Buzz");
+    // log::error!("Fizzle");
+    let a: u32 = ACC;
+    let b: u32 = 0x01020304;
+    let c: u32;
+    asm!("uqadd8 {2}, {0}, {1}", in(reg) a, in(reg) b, out(reg) c);
+    ACC = c;
+    log::info!("A: {:#08x} B: {:#08x} C: {:#08x}", a, b, c);
+}
+
+#[cfg(not(target_abi = "eabihf"))]
+#[no_mangle]
+pub unsafe extern "C" fn example_foo() {
+    unimplemented!();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Saturating `quadd8` accumulation of uint32_t's from both C and Rust code that is logged via the LOG_INF macro invocation and the Rust write! format invocation.

Instructions are only compiled on Rust for Cortex-M4 and Cortex-M33 behind the `dsp` target feature via the nightly features for checking the abi and feature.